### PR TITLE
fix "no such file or directory"

### DIFF
--- a/etc/brew-wrap
+++ b/etc/brew-wrap
@@ -60,7 +60,7 @@ brew () {
   fi
 
   # Execute command
-  local brewfile=$(cat $(brew-file get_files))
+  local brewfile=$(cat $(brew-file get_files)) 2>/dev/null # supress warnings for non-existant brewfiles
   eval $env $exe "$@"
   ret=$?
 


### PR DESCRIPTION
Suppress errors when attempting to harmlessly include a non-existent brewfile.

Context: on some systems I intentionally don't set a shell variable, so `file ./${INCLUDE_EXTRA}-casks.Brewfile` won't pull in casks I don't want on that system. But I now get the error:
```
brew file update
cat: /Users/zach/.dotfiles/brewfile/-casks.Brewfile: No such file or directory
```